### PR TITLE
Inactive timestamps

### DIFF
--- a/org-books.el
+++ b/org-books.el
@@ -89,7 +89,7 @@
   "Insert book template at current position and buffer"
   (insert (make-string level ?*) " " title "\n")
   (org-set-property "AUTHOR" author)
-  (org-set-property "ADDED" (format-time-string "<%Y-%02m-%02d>"))
+  (org-set-property "ADDED" (format-time-string "[%Y-%02m-%02d]"))
   (-each props (lambda (p) (org-set-property (car p) (cdr p)))))
 
 (defun org-books-goto-place ()


### PR DESCRIPTION
I found this change useful since I wish to keep track of the added date but not have it show up in the agenda or elsewhere. It seems quite possible you had a good reason for active timestamps that didn't cross my mind - if so, forget this!