### PR TITLE
Fetch Author Name from Authors in JSON Response

### DIFF
--- a/org-books-get-details.el
+++ b/org-books-get-details.el
@@ -97,7 +97,8 @@
          (isbn (car (hash-table-keys json)))
          (data (gethash isbn json))
          (title (gethash "title" data))
-         (author (gethash "by_statement" data)))
+         (authors (gethash "authors" data))
+         (author (gethash "name" (car authors))))
     (list title author `(("ISBN" . ,url)))))
 
 (provide 'org-books-get-details)

--- a/test/org-books-test.el
+++ b/test/org-books-test.el
@@ -1,6 +1,6 @@
 ;; Tests
 
-(load-file "org-books-get-details.el")
+(load-file "../org-books-get-details.el")
 
 (ert-deftest test-goodreads-url ()
   (let ((urls (list "https://www.goodreads.com"
@@ -38,4 +38,4 @@
   (let* ((isbn "0517149257")
 	       (res (org-books-get-details-isbn (org-books-get-url-from-isbn isbn))))
     (should (string-equal (first res) "The Ultimate Hitchhiker's Guide"))
-    (should (string-equal (second res) "Douglas Adams."))))
+    (should (string-equal (second res) "Douglas Adams"))))


### PR DESCRIPTION
Instead of relying on `by_statement` (which seems to require
`jscmd=details`), the more stable `authors` key (which is available in a
`jscmd=data` request) is searched, and the first author in the list is
found.

This can be further updated to handle multiple authors if a book has them.